### PR TITLE
Implement `write-tree` command

### DIFF
--- a/docs/src/3-staging/staging.md
+++ b/docs/src/3-staging/staging.md
@@ -4,6 +4,7 @@ Implement commands for working with the local staging area:
 - `rm`
 - `mv`
 - `restore`
+- `write-tree`
 
 Running `git help add`:
 ```
@@ -26,3 +27,5 @@ I thought `update-index` is a simpler version of `add`, but actually it's more o
 With the index implemented for the `add` command, implementing `rm`, `mv`, and `restore` should be quite straightforward, just making changes to/using that index.
 
 For now, I'll just implement `restore` with very basic functionality, to restore files in the working directory from the index. I will add further functionality once commits and branches are implemented.
+
+The `write-tree` command adds Git tree objects to the Git object store based on the current index. Efficient implementation relies on the Git index being maintained in special sorted order: https://stackoverflow.com/questions/72128688/how-git-write-tree-works-internally

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,16 +1,9 @@
 use crate::{
-    Cli, 
-    CliCommand,
-    repo::RepoState, 
-    error::RustGitError, 
-    add::command::AddCommand, 
-    cat_file::command::CatFileCommand, 
-    hash_object::command::HashObjectCommand, 
-    init::command::InitCommand, 
-    ls_files::command::LsFilesCommand, 
-    mv::command::MvCommand, 
-    restore::command::RestoreCommand, 
-    rm::command::RmCommand, 
+    add::command::AddCommand, cat_file::command::CatFileCommand, error::RustGitError,
+    hash_object::command::HashObjectCommand, init::command::InitCommand,
+    ls_files::command::LsFilesCommand, mv::command::MvCommand, repo::RepoState,
+    restore::command::RestoreCommand, rm::command::RmCommand,
+    write_tree::command::WriteTreeCommand, Cli, CliCommand,
 };
 
 pub(crate) trait GitCommand {
@@ -24,22 +17,20 @@ pub(crate) trait GitCommand {
 // actually cares about.
 pub(crate) fn from_cli(value: Cli) -> Result<Box<dyn GitCommand>, RustGitError> {
     match value.command {
-        CliCommand::Init(args) => 
-            Ok(Box::new(InitCommand::new(args, value.git_dir, value.work_tree))),
-        CliCommand::Add(args) => 
-            Ok(Box::new(AddCommand::new(args))),
-        CliCommand::HashObject(args) => 
-            Ok(Box::new(HashObjectCommand::new(args))),
-        CliCommand::CatFile(args) => 
-            CatFileCommand::new(args).map(|res| Box::new(res) as Box<dyn GitCommand>),
-        CliCommand::LsFiles(args) => 
-            Ok(Box::new(LsFilesCommand::new(args))),
-        CliCommand::Rm(args) => 
-            Ok(Box::new(RmCommand::new(args))),
-        CliCommand::Mv(args) => 
-            Ok(Box::new(MvCommand::new(args))),
-        CliCommand::Restore(args) => 
-            Ok(Box::new(RestoreCommand::new(args))),
-
+        CliCommand::Init(args) => Ok(Box::new(InitCommand::new(
+            args,
+            value.git_dir,
+            value.work_tree,
+        ))),
+        CliCommand::Add(args) => Ok(Box::new(AddCommand::new(args))),
+        CliCommand::HashObject(args) => Ok(Box::new(HashObjectCommand::new(args))),
+        CliCommand::CatFile(args) => {
+            CatFileCommand::new(args).map(|res| Box::new(res) as Box<dyn GitCommand>)
+        }
+        CliCommand::LsFiles(args) => Ok(Box::new(LsFilesCommand::new(args))),
+        CliCommand::Rm(args) => Ok(Box::new(RmCommand::new(args))),
+        CliCommand::Mv(args) => Ok(Box::new(MvCommand::new(args))),
+        CliCommand::Restore(args) => Ok(Box::new(RestoreCommand::new(args))),
+        CliCommand::WriteTree(args) => Ok(Box::new(WriteTreeCommand::new(args))),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-mod repo;
 mod command;
 mod config;
 mod error;
 mod hash;
+mod index;
 mod object;
 mod options;
-mod index;
+mod repo;
 
 mod add;
 mod cat_file;
@@ -15,6 +15,7 @@ mod ls_files;
 mod mv;
 mod restore;
 mod rm;
+mod write_tree;
 
 use std::{path::PathBuf, process::ExitCode};
 
@@ -31,31 +32,26 @@ use mv::cli::MvArgs;
 use repo::GitRepo;
 use restore::cli::RestoreArgs;
 use rm::cli::RmArgs;
+use write_tree::cli::WriteTreeArgs;
 
-fn parse_config_override(s: &str) -> Result<(String,String), String> {
+fn parse_config_override(s: &str) -> Result<(String, String), String> {
     match s.find('=') {
-        Some(eq_idx) => {
-            Ok((String::from(&s[0..eq_idx]), String::from(&s[eq_idx+1..])))
-        }
-        None => {
-            Ok((String::from(s), String::from("true")))
-        }
+        Some(eq_idx) => Ok((String::from(&s[0..eq_idx]), String::from(&s[eq_idx + 1..]))),
+        None => Ok((String::from(s), String::from("true"))),
     }
 }
 
-fn parse_config_env(s: &str) -> Result<(String,String), String> {
+fn parse_config_env(s: &str) -> Result<(String, String), String> {
     match s.find('=') {
         Some(eq_idx) => {
-            let env_var =  &s[eq_idx+1..];
+            let env_var = &s[eq_idx + 1..];
             if env_var.is_empty() {
                 Err(String::from("Expected env_var in config-env"))
             } else {
                 Ok((String::from(&s[0..eq_idx]), String::from(env_var)))
             }
         }
-        None => {
-            Err(String::from("Expected '=' in config-env"))
-        }
+        None => Err(String::from("Expected '=' in config-env")),
     }
 }
 
@@ -77,7 +73,7 @@ struct Cli {
     ///
     ///    git --git-dir=a.git --work-tree=b -C c status
     ///    git --git-dir=c/a.git --work-tree=c/b status
-    #[arg(short='C', value_name="path")]
+    #[arg(short = 'C', value_name = "path")]
     working_directory: Vec<PathBuf>,
 
     /// Pass a configuration parameter to the command. The value given will
@@ -101,14 +97,14 @@ struct Cli {
     /// the <envvar> does not exist in the environment.  <envvar> may not
     /// contain an equals sign to avoid ambiguity with <name> containing
     /// one.
-    /// 
+    ///
     /// This is useful for cases where you want to pass transitory
     /// configuration options to git, but are doing so on OS’s where other
     /// processes might be able to read your cmdline (e.g.
     /// /proc/self/cmdline), but not your environ (e.g.
     /// /proc/self/environ). That behavior is the default on Linux, but may
     /// not be on your system.
-    /// 
+    ///
     /// Note that this might add security for variables such as
     /// http.extraHeader where the sensitive information is part of the
     /// value, but not e.g.  url.<base>.insteadOf where the sensitive
@@ -120,7 +116,7 @@ struct Cli {
     /// also be controlled by setting the GIT_EXEC_PATH environment
     /// variable. If no path is given, git will print the current setting
     /// and then exit.
-    #[arg(long, value_name="path", env="GIT_EXEC_PATH")]
+    #[arg(long, value_name = "path", env = "GIT_EXEC_PATH")]
     exec_path: Option<PathBuf>,
 
     /// Print the path, without trailing slash, where Git’s HTML
@@ -145,7 +141,7 @@ struct Cli {
     paginate: bool,
 
     /// Do not pipe Git output into a pager.
-    #[arg(short='P', long)]
+    #[arg(short = 'P', long)]
     no_pager: bool,
 
     /// Set the path to the repository (".git" directory). This can also be
@@ -161,10 +157,10 @@ struct Cli {
     /// working tree, you should tell Git where the top-level of the
     /// working tree is, with the --work-tree=<path> option (or
     /// GIT_WORK_TREE environment variable)
-    /// 
+    ///
     /// If you just want to run git as if it was started in <path> then use
     /// git -C <path>.
-    #[arg(long, value_name="path", env="GIT_DIR")]
+    #[arg(long, value_name = "path", env = "GIT_DIR")]
     git_dir: Option<PathBuf>,
 
     /// Set the path to the working tree. It can be an absolute path or a
@@ -172,20 +168,20 @@ struct Cli {
     /// controlled by setting the GIT_WORK_TREE environment variable and
     /// the core.worktree configuration variable (see core.worktree in git-
     /// config(1) for a more detailed discussion).
-    #[arg(long, value_name="path", env="GIT_WORK_TREE")]
+    #[arg(long, value_name = "path", env = "GIT_WORK_TREE")]
     work_tree: Option<PathBuf>,
 
     /// Set the Git namespace. See gitnamespaces(7) for more details.
     /// Equivalent to setting the GIT_NAMESPACE environment variable.
-    #[arg(long, value_name="path", env="GIT_NAMESPACE")]
+    #[arg(long, value_name = "path", env = "GIT_NAMESPACE")]
     namespace: Option<PathBuf>,
 
     /// Currently for internal use only. Set a prefix which gives a path
     /// from above a repository down to its root. One use is to give
     /// submodules context about the superproject that invoked it.
-    #[arg(long, value_name="path")]
+    #[arg(long, value_name = "path")]
     super_perfix: Option<PathBuf>,
-    
+
     /// Treat the repository as a bare repository. If GIT_DIR environment
     /// is not set, it is set to the current working directory.
     #[arg(long)]
@@ -199,30 +195,30 @@ struct Cli {
     /// Treat pathspecs literally (i.e. no globbing, no pathspec magic).
     /// This is equivalent to setting the GIT_LITERAL_PATHSPECS environment
     /// variable to 1.
-    #[arg(long, env="GIT_LITERAL_PATHSPECS")]
+    #[arg(long, env = "GIT_LITERAL_PATHSPECS")]
     literal_pathspecs: bool,
 
     /// Add "glob" magic to all pathspec. This is equivalent to setting the
     /// GIT_GLOB_PATHSPECS environment variable to 1. Disabling globbing on
     /// individual pathspecs can be done using pathspec magic ":(literal)"
-    #[arg(long, env="GIT_GLOB_PATHSPECS")]
+    #[arg(long, env = "GIT_GLOB_PATHSPECS")]
     glob_pathspecs: bool,
 
     /// Add "literal" magic to all pathspec. This is equivalent to setting
     /// the GIT_NOGLOB_PATHSPECS environment variable to 1. Enabling
     /// globbing on individual pathspecs can be done using pathspec magic
     /// ":(glob)"
-    #[arg(long, env="GIT_NOGLOB_PATHSPECS")]
+    #[arg(long, env = "GIT_NOGLOB_PATHSPECS")]
     noglob_pathspecs: bool,
 
     /// Add "icase" magic to all pathspec. This is equivalent to setting
     /// the GIT_ICASE_PATHSPECS environment variable to 1.
-    #[arg(long, env="GIT_ICASE_PATHSPECS")]
+    #[arg(long, env = "GIT_ICASE_PATHSPECS")]
     icase_pathspecs: bool,
 
     /// Do not perform optional operations that require locks. This is
     /// equivalent to setting the GIT_OPTIONAL_LOCKS to 0.
-    #[arg(long, env="GIT_OPTIONAL_LOCKS")]
+    #[arg(long, env = "GIT_OPTIONAL_LOCKS")]
     no_optional_locks: bool,
 
     /// List commands by group. This is an internal/experimental option and
@@ -233,7 +229,7 @@ struct Cli {
     /// command-list.txt), nohelpers (exclude helper commands), alias and
     /// config (retrieve command list from config variable
     /// completion.commands)
-    #[arg(long, value_name="group")]
+    #[arg(long, value_name = "group")]
     list_cmds: Vec<String>,
 
     #[command(subcommand)]
@@ -242,9 +238,9 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum CliCommand {
-    #[clap(alias="init-db")]
+    #[clap(alias = "init-db")]
     Init(InitArgs),
-    #[clap(alias="stage")]
+    #[clap(alias = "stage")]
     Add(AddArgs),
     HashObject(HashObjectArgs),
     CatFile(CatFileArgs),
@@ -252,6 +248,7 @@ enum CliCommand {
     Rm(RmArgs),
     Mv(MvArgs),
     Restore(RestoreArgs),
+    WriteTree(WriteTreeArgs),
 }
 
 fn load_repo_and_execute(cli: Cli) -> Result<(), RustGitError> {
@@ -278,18 +275,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_config_override()
-    {
-        assert_eq!(parse_config_override("test=blah"), Ok((String::from("test"), String::from("blah"))));
-        assert_eq!(parse_config_override("test="), Ok((String::from("test"), String::from(""))));
-        assert_eq!(parse_config_override("test"), Ok((String::from("test"), String::from("true"))));
+    fn test_parse_config_override() {
+        assert_eq!(
+            parse_config_override("test=blah"),
+            Ok((String::from("test"), String::from("blah")))
+        );
+        assert_eq!(
+            parse_config_override("test="),
+            Ok((String::from("test"), String::from("")))
+        );
+        assert_eq!(
+            parse_config_override("test"),
+            Ok((String::from("test"), String::from("true")))
+        );
     }
 
     #[test]
-    fn test_parse_config_env()
-    {
-        assert_eq!(parse_config_env("test=blah"), Ok((String::from("test"), String::from("blah"))));
-        assert_eq!(parse_config_env("test="), Err(String::from("Expected env_var in config-env")));
-        assert_eq!(parse_config_env("test"), Err(String::from("Expected '=' in config-env")));
+    fn test_parse_config_env() {
+        assert_eq!(
+            parse_config_env("test=blah"),
+            Ok((String::from("test"), String::from("blah")))
+        );
+        assert_eq!(
+            parse_config_env("test="),
+            Err(String::from("Expected env_var in config-env"))
+        );
+        assert_eq!(
+            parse_config_env("test"),
+            Err(String::from("Expected '=' in config-env"))
+        );
     }
 }

--- a/src/write_tree/cli.rs
+++ b/src/write_tree/cli.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+use clap::Args;
+
+#[derive(Args, Debug)]
+#[command(about = "Create a tree object from the current index")]
+#[command(long_about = "
+Creates a tree object using the current index. The name of the new tree object is printed to standard output.
+
+The index must be in a fully merged state.
+
+Conceptually, git write-tree sync()s the current index contents into a set of tree files. In order to have
+that match what is actually in your directory right now, you need to have done a git update-index phase before
+you did the git write-tree.
+")]
+pub(crate) struct WriteTreeArgs {
+    /// Normally git write-tree ensures that the objects referenced by the directory exist in the object database.
+    /// This option disables this check.
+    #[arg(long)]
+    pub(crate) missing_ok: bool,
+
+    /// Writes a tree object that represents a subdirectory <prefix>. This can be used to write the tree object
+    /// for a subproject that is in the named subdirectory.
+    #[arg(long)]
+    pub(crate) prefix: Option<PathBuf>,
+}

--- a/src/write_tree/command.rs
+++ b/src/write_tree/command.rs
@@ -1,0 +1,25 @@
+use crate::{command::GitCommand, repo::RepoState, RustGitError};
+
+use super::cli::WriteTreeArgs;
+
+pub(crate) struct WriteTreeCommand {
+    args: WriteTreeArgs,
+}
+
+impl WriteTreeCommand {
+    pub fn new(args: WriteTreeArgs) -> WriteTreeCommand {
+        WriteTreeCommand { args }
+    }
+}
+
+impl GitCommand for WriteTreeCommand {
+    fn execute(&self, repo_state: RepoState) -> Result<(), RustGitError> {
+        let repo = repo_state.try_get()?;
+
+        let object_id = repo.write_index_as_tree()?;
+
+        println!("{object_id}");
+
+        Ok(())
+    }
+}

--- a/src/write_tree/mod.rs
+++ b/src/write_tree/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod cli;
+pub(crate) mod command;

--- a/tests/write-tree.rs
+++ b/tests/write-tree.rs
@@ -1,0 +1,58 @@
+mod integration_tests {
+    use assert_cmd::{assert::OutputAssertExt, Command};
+    use test_helpers::{TempDirExt, TestGitRepo};
+
+    #[test]
+    fn should_write_tree_object_to_repo() {
+        let test_git_repo = TestGitRepo::new();
+        test_git_repo.temp_dir.create_test_file("test.txt", b"test");
+        test_git_repo
+            .temp_dir
+            .create_test_file("test2.txt", b"test2");
+        test_git_repo.temp_dir.create_test_dir("test_dir");
+        test_git_repo
+            .temp_dir
+            .create_test_file("test_dir/test_in_dir.txt", b"test_in_dir");
+
+        test_git_repo.init();
+        test_git_repo.add("test.txt test2.txt test_dir");
+
+        let cmd = Command::cargo_bin("rust-git")
+            .unwrap()
+            .arg("write-tree")
+            .current_dir(test_git_repo.temp_dir.path())
+            .unwrap();
+
+        cmd.assert()
+            .success()
+            .stdout("03f9b0b16745d6529b86f7e7cf12bb0a254b6b8e\n");
+
+        let cat_file_type =
+            test_git_repo.cat_file("-t", "03f9b0b16745d6529b86f7e7cf12bb0a254b6b8e");
+
+        assert_eq!(cat_file_type, "tree");
+
+        let cat_file_content =
+            test_git_repo.cat_file("-p", "03f9b0b16745d6529b86f7e7cf12bb0a254b6b8e");
+
+        assert_eq!(
+            cat_file_content,
+            "040000 tree c7c1cd98552375307d7d3ac561793842c3a47abd\ttest_dir
+100644 blob 30d74d258442c7c65512eafab474568dd706c430\ttest.txt
+100644 blob d606037cb232bfda7788a8322492312d55b2ae9d\ttest2.txt"
+        );
+
+        let cat_sub_tree_type =
+            test_git_repo.cat_file("-t", "c7c1cd98552375307d7d3ac561793842c3a47abd");
+
+        assert_eq!(cat_sub_tree_type, "tree");
+
+        let cat_sub_tree_content =
+            test_git_repo.cat_file("-p", "c7c1cd98552375307d7d3ac561793842c3a47abd");
+
+        assert_eq!(
+            cat_sub_tree_content,
+            "100644 blob 27961cd8c28d3fd780672e10e8c7c25d6eee10ee\ttest_in_dir.txt"
+        );
+    }
+}


### PR DESCRIPTION
Implements the `write-tree` porcelain command, to write the current index out as a tree object in the repository.