### PR TITLE
Implement basic `commit` command

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,7 @@
 use crate::{
     add::command::AddCommand,
     cat_file::command::CatFileCommand,
+    commit::command::CommitCommand,
     commit_tree::command::CommitTreeCommand,
     error::RustGitError,
     hash_object::command::HashObjectCommand,
@@ -43,6 +44,9 @@ pub(crate) fn from_cli(value: Cli) -> Result<Box<dyn GitCommand>, RustGitError> 
         CliCommand::Mv(args) => Ok(Box::new(MvCommand::new(args))),
         CliCommand::Restore(args) => Ok(Box::new(RestoreCommand::new(args))),
         CliCommand::WriteTree(args) => Ok(Box::new(WriteTreeCommand::new(args))),
+        CliCommand::Commit(args) => {
+            CommitCommand::new(args).map(|res| Box::new(res) as Box<dyn GitCommand>)
+        }
         CliCommand::CommitTree(args) => {
             CommitTreeCommand::new(args).map(|res| Box::new(res) as Box<dyn GitCommand>)
         }

--- a/src/commit/cli.rs
+++ b/src/commit/cli.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use clap::Args;
+
+#[derive(Args, Debug)]
+#[command(about = "Record changes to the repository")]
+#[command(long_about = "
+Create a new commit containing the current contents of the index and the given log message describing the
+changes. The new commit is a direct child of HEAD, usually the tip of the current branch, and the branch is
+updated to point to it (unless no branch is associated with the working tree, in which case HEAD is \"detached\"
+as described in git-checkout(1)).
+
+The content to be committed can be specified in several ways:
+
+1. by using git-add(1) to incrementally \"add\" changes to the index before using the commit command (Note:
+    even modified files must be \"added\");
+
+2. by using git-rm(1) to remove files from the working tree and the index, again before using the commit
+    command;
+
+3. by listing files as arguments to the commit command (without --interactive or --patch switch), in which
+    case the commit will ignore changes staged in the index, and instead record the current content of the
+    listed files (which must already be known to Git);
+
+4. by using the -a switch with the commit command to automatically \"add\" changes from all known files (i.e.
+    all files that are already listed in the index) and to automatically \"rm\" files in the index that have
+    been removed from the working tree, and then perform the actual commit;
+
+5. by using the --interactive or --patch switches with the commit command to decide one by one which files or
+    hunks should be part of the commit in addition to contents in the index, before finalizing the operation.
+    See the \"Interactive Mode\" section of git-add(1) to learn how to operate these modes.
+
+The --dry-run option can be used to obtain a summary of what is included by any of the above for the next
+commit by giving the same set of parameters (options and paths).
+
+If you make a commit and then find a mistake immediately after that, you can recover from it with git reset.
+")]
+pub(crate) struct CommitArgs {
+    /// Use the given <msg> as the commit message. If multiple -m options are given, their values are concatenated
+    /// as separate paragraphs.
+    ///
+    /// The -m option is mutually exclusive with -c, -C, and -F.
+    #[arg(short, long("message"), value_name = "msg")]
+    pub messages: Vec<String>,
+}

--- a/src/commit/command.rs
+++ b/src/commit/command.rs
@@ -1,0 +1,48 @@
+use crate::{command::GitCommand, repo::RepoState, RustGitError};
+
+use super::cli::CommitArgs;
+
+pub(crate) struct CommitCommand {
+    pub message: String,
+}
+
+impl CommitCommand {
+    pub fn new(args: CommitArgs) -> Result<CommitCommand, RustGitError> {
+        let message = args.messages.join("\n");
+
+        if message.is_empty() {
+            return Err(RustGitError::new("commit message cannot be empty"));
+        }
+
+        Ok(CommitCommand { message })
+    }
+}
+
+impl GitCommand for CommitCommand {
+    fn execute(&self, repo_state: RepoState) -> Result<(), RustGitError> {
+        let repo = repo_state.try_get()?;
+
+        // Write index as tree.
+        let tree_id = repo.write_index_as_tree()?;
+
+        let (current_head_branch, current_head_ref) = repo.get_head_ref()?;
+
+        let current_head_branch = if let Some(current_head_branch) = current_head_branch {
+            current_head_branch
+        } else {
+            return Err(RustGitError::new("couldn't load HEAD"));
+        };
+
+        let parents = current_head_ref.map_or(vec![], |current_head| vec![current_head]);
+
+        // Create commit object with parent set to current HEAD.
+        let commit_id = repo.write_commit(&tree_id, &parents, &self.message)?;
+
+        // Update HEAD branch to point to newly created commit.
+        repo.update_ref(&current_head_branch, &commit_id.to_string(), None)?;
+
+        println!("{commit_id}");
+
+        Ok(())
+    }
+}

--- a/src/commit/mod.rs
+++ b/src/commit/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod cli;
+pub(crate) mod command;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod repo;
 
 mod add;
 mod cat_file;
+mod commit;
 mod commit_tree;
 mod hash_object;
 mod init;
@@ -30,6 +31,7 @@ use cat_file::cli::CatFileArgs;
 use clap::{Parser, Subcommand};
 
 use command::from_cli;
+use commit::cli::CommitArgs;
 use commit_tree::cli::CommitTreeArgs;
 use error::RustGitError;
 use hash_object::cli::HashObjectArgs;
@@ -259,6 +261,7 @@ enum CliCommand {
     Mv(MvArgs),
     Restore(RestoreArgs),
     WriteTree(WriteTreeArgs),
+    Commit(CommitArgs),
     CommitTree(CommitTreeArgs),
     UpdateRef(UpdateRefArgs),
     SymbolicRef(SymbolicRefArgs),

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -116,20 +116,22 @@ impl GitRefs {
         self.try_read_ref(&tag_path)
     }
 
-    pub(crate) fn get_head_ref(&self) -> Result<Option<GitObjectId>, RustGitError> {
+    pub(crate) fn get_head_ref(
+        &self,
+    ) -> Result<(Option<String>, Option<GitObjectId>), RustGitError> {
         if let Some(head_ref_value) = self.get_symbolic_ref("HEAD")? {
             if !head_ref_value.starts_with("ref: ") {
                 return Err(RustGitError::new("HEAD is in detatched state"));
             }
 
-            let ref_path = self
-                .git_dir
-                .join(head_ref_value.trim_start_matches("ref: "));
+            let head_ref_branch = head_ref_value.trim_start_matches("ref: ");
+
+            let ref_path = self.git_dir.join(head_ref_branch);
 
             let ref_id = self.try_read_ref(&ref_path)?.map(GitObjectId::new);
-            Ok(ref_id)
+            Ok((Some(head_ref_branch.to_string()), ref_id))
         } else {
-            Ok(None)
+            Ok((None, None))
         }
     }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -479,7 +479,9 @@ impl GitRepo {
         self.refs.list_tags()
     }
 
-    pub(crate) fn get_head_ref(&self) -> Result<Option<GitObjectId>, RustGitError> {
+    pub(crate) fn get_head_ref(
+        &self,
+    ) -> Result<(Option<String>, Option<GitObjectId>), RustGitError> {
         self.refs.get_head_ref()
     }
 }

--- a/src/tag/command.rs
+++ b/src/tag/command.rs
@@ -66,7 +66,7 @@ impl GitCommand for TagCommand {
                 let object_id = if let Some(object_id) = &create_cmd.object_id {
                     object_id
                 } else {
-                    if let Some(head_ref) = repo.get_head_ref()? {
+                    if let (_, Some(head_ref)) = repo.get_head_ref()? {
                         &head_ref.clone()
                     } else {
                         return Err(RustGitError::new("no HEAD ref"));


### PR DESCRIPTION
Adds very simple version of `commit` command, only supporting `-m` flag.